### PR TITLE
send podId in cookie and restore

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -1,0 +1,3 @@
+PORT=3000
+PUPPETEER_HEADLESS=true
+COOKIE_SECRET=eqfqefqhfnqelnncs12AS@E@djjdjijAXWF

--- a/backend/src/api/searchController.js
+++ b/backend/src/api/searchController.js
@@ -1,7 +1,9 @@
 const express = require("express");
 const router = express.Router();
 const swiggyService = require("../services/swiggyService");
-const storeState = require("../state/storeState");
+const { decodePodId } = require("../../utils/cookie");
+
+const DEFAULT_POD_ID = 1374258;
 
 router.post("/", async (req, res) => {
     try {
@@ -20,7 +22,17 @@ router.post("/", async (req, res) => {
             zepto: { success: false, items: [] }
         };
 
-            const podId = storeState.swiggy.podId;
+            let podId = DEFAULT_POD_ID;
+
+            try {
+                if (req.cookies?.swiggy_pod) {
+                podId = decodePodId(req.cookies.swiggy_pod);
+                console.log("Using podId from cookie:", podId);
+            }
+            } catch (e) {
+                console.warn("Invalid pod cookie, using default");
+                podId = DEFAULT_POD_ID;
+            }
             const items = await swiggyService.searchItems(podId, query);
             output.swiggy = { success: true, items };
 

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,5 +1,9 @@
+require("dotenv").config();
 const express = require("express");
 const cors = require("cors");
+const cookieParser = require("cookie-parser");
+
+
 
 const apiRoutes = require("./api");
 
@@ -7,7 +11,7 @@ const app = express();
 
 app.use(cors());
 app.use(express.json());
-
+app.use(cookieParser(process.env.COOKIE_SECRET));
 // Everything goes under /api
 app.use("/api", apiRoutes);
 

--- a/backend/src/scrapers/swiggyLocation.js
+++ b/backend/src/scrapers/swiggyLocation.js
@@ -47,7 +47,7 @@ module.exports = async function selectLocation(page, { lat, lng, address }) {
     }
 
     const podId = findPod(json);
-    if (!podId) throw new Error("podId not found");
-
+    if (!podId) console.log("podId not found");
+    
     return podId;
 };


### PR DESCRIPTION
PodId is returned as an encrypted string in the cookie and will be decoded if the search API is called with the same, otherwise default podID will be used . 

//TODO 
1. corresponding functions will need to be added in cookie.js file to support encyption/decryption of other cookie values

Backend Logs :- 
ekaksha@Elohim:~/Ubuntu Backup/projects/sastamaal/backend$ npm start

> quickcompare-backend@0.1.0 start
> node src/server.js

[dotenv@17.2.3] injecting env (3) from .env -- tip: 🔄 add secrets lifecycle management: https://dotenvx.com/ops
Backend running at http://localhost:3000
Calling Swiggy Service for location Update

podId not found
Swiggy location set failed, keeping default podId, no cookie set
Calling Swiggy Service for location Update

podId not found
Swiggy location set failed, keeping default podId, no cookie set
Calling Swiggy Service for location Update

Swiggy location set, podId: 1404590
Using podId from cookie: 1404590
Visiting Instamart...
Waiting for Instamart app initialization...
Saved raw Swiggy search JSON -> /home/ekaksha/Ubuntu Backup/projects/sastamaal/backend/logs/swiggy_search_1766404025849.json
Using podId from cookie: 1404590
Visiting Instamart...
Waiting for Instamart app initialization...
Saved raw Swiggy search JSON -> /home/ekaksha/Ubuntu Backup/projects/sastamaal/backend/logs/swiggy_search_1766404041637.json

Curl Req/Resp :- 
`ekaksha@Elohim:~/Ubuntu Backup/projects/sastamaal$ curl -v -X POST http://localhost:3000/api/location      -H "Content-Type: application/json"      -d '{"lat":12.935, "lng":77.614, "address":"Koramangala, Bangalore"}'
Note: Unnecessary use of -X or --request, POST is already inferred.
* Host localhost:3000 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:3000...
* Connected to localhost (::1) port 3000
> POST /api/location HTTP/1.1
> Host: localhost:3000
> User-Agent: curl/8.5.0
> Accept: */*
> Content-Type: application/json
> Content-Length: 64
>
< HTTP/1.1 200 OK
< X-Powered-By: Express
< Access-Control-Allow-Origin: *
< Set-Cookie: **_swiggy_pod=eyJpdiI6IjNlMTkzNWI3YjhlZmI0NWMyNGFkYmYyYyIsImRhdGEiOiI1ZGY5N2U2YTk4NThlOSIsInRhZyI6IjVhMTIxOTYyYTc0YzZhNTY4MTQ2NDY0ZTFhMDNkMzM5In0%3D_**; Max-Age=86400; Path=/; Expires=Tue, 23 Dec 2025 11:45:47 GMT; HttpOnly; Secure; SameSite=Lax
< Content-Type: application/json; charset=utf-8
< Content-Length: 74
< ETag: W/"4a-PVKv1HxGAYPKcyK6jtPqHOlmAR4"
< Date: Mon, 22 Dec 2025 11:45:47 GMT
< Connection: keep-alive
< Keep-Alive: timeout=5
<
* Connection #0 to host localhost left intact
{"swiggy":"success","blinkit":"not_implemented","zepto":"not_implemented"}



ekaksha@Elohim:~/Ubuntu Backup/projects/sastamaal$ curl -v -X POST http://localhost:3000/api/search   -H "Content-Type: application/json"   -H "Cookie: swiggy_pod=eyJpdiI6IjNlMTkzNWI3YjhlZmI0NWMyNGFkYmYyYyIsImRhdGEiOiI1ZGY5N2U2YTk4NThlOSIsInRhZyI6IjVhMTIxOTYyYTc0YzZhNTY4MTQ2NDY0ZTFhMDNkMzM5In0%3D"   -d '{"query":"milk"}' |jq`